### PR TITLE
Implement monitoring capabilities

### DIFF
--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -1,8 +1,31 @@
 import LastClient from '@musicorum/lastfm'
 import {LastfmError, LastfmErrorCode} from '@musicorum/lastfm/dist/error/LastfmError.js'
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const client = new LastClient(process.env.LASTFM_KEY!)
+class MonitoredClient extends LastClient {
+  constructor () {
+    super(process.env.LASTFM_KEY!)
+  }
+
+  onRequestStarted(
+    method: string,
+    params: Record<string, string>,
+    internalData: Record<string, any>
+  ) {
+    internalData.startedAt = Date.now()
+    console.log('request to', method, 'started')
+  }
+
+  onRequestFinished(
+    method: string,
+    params: Record<string, string>,
+    internalData: Record<string, never>,
+    response: Record<string, never>
+  ) {
+    console.log('request to', method, 'finished,', 'took', Date.now() - internalData.startedAt, 'ms')
+  }
+}
+
+const client = new MonitoredClient()
 
 async function main() {
   const user1 = await client.request('user.getInfo', { user: 'metye' })

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musicorum/lastfm",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "",
   "main": "dist/LastClient.js",
   "types": "dist/LastClient.d.ts",

--- a/lib/src/error/LastfmError.ts
+++ b/lib/src/error/LastfmError.ts
@@ -79,7 +79,7 @@ export enum LastfmErrorCode {
   TEMPORARY_ERROR = 16,
 
   /**
-   * User requires to be logged in to use this
+   * User requires to be logged in to use this method
    * This may be caused when trying to get some user's data with restricted privicy
    */
   REQUIRES_LOGIN = 17,


### PR DESCRIPTION
Fixes an issue where fetch wouldn't work and allows for implementations of `LastClient` to listen for requests to the last.fm API, allowing for integration with monitoring/logging tools, such as Prometheus and Datadog.