### PR TITLE
Add getInfo method for artists, albums and tracks

### DIFF
--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -1,4 +1,5 @@
 import { LastClient } from '@musicorum/lastfm'
+import { deepStrictEqual } from 'assert'
 
 class MonitoredClient extends LastClient {
   constructor () {
@@ -51,9 +52,9 @@ async function main() {
     username: 'blueslimee'
   })
 
-  console.log(`blueslimee has ${trackInfo2.user!.playCount} plays on ${trackInfo2.name} vs ${trackInfo.track.userplaycount} plays on ${trackInfo.track.name}`)
-
-
+  const nonExistingTrack = await client.track.getInfo('21 Reasons', 'SEULBI')
+  deepStrictEqual(nonExistingTrack, undefined)
+  console.log(`blueslimee has ${trackInfo2!.user!.playCount} plays on ${trackInfo2!.name} vs ${trackInfo!.track!.userplaycount} plays on ${trackInfo!.track!.name}`)
   
   const page1 = recentTracks.getPage(1)
   const page2 = await recentTracks.fetchPage(2)

--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -1,5 +1,4 @@
 import { LastClient } from '@musicorum/lastfm'
-import { LastfmError, LastfmErrorCode } from '@musicorum/lastfm/dist/error/LastfmError.js'
 
 class MonitoredClient extends LastClient {
   constructor () {
@@ -40,6 +39,20 @@ async function main() {
     extended: false
   })
   console.log(`${recentTracks.totalResults} results in ${recentTracks.totalPages} pages`)
+
+  const trackInfo = await client.request('track.getInfo', {
+    artist: 'NewJeans',
+    track: 'OMG',
+    autocorrect: '1',
+    username: 'blueslimee'
+  })
+  const trackInfo2 = await client.track.getInfo('28 Reasons', 'SEULGI', {
+    autoCorrect: true,
+    username: 'blueslimee'
+  })
+
+  console.log(`blueslimee has ${trackInfo2.user!.playCount} plays on ${trackInfo2.name} vs ${trackInfo.track.userplaycount} plays on ${trackInfo.track.name}`)
+
 
   
   const page1 = recentTracks.getPage(1)

--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -12,7 +12,6 @@ class MonitoredClient extends LastClient {
     internalData: Record<string, any>
   ) {
     internalData.startedAt = Date.now()
-    console.log('request to', method, 'started')
   }
 
   onRequestFinished(
@@ -31,10 +30,7 @@ async function main() {
   const user1 = await client.request('user.getInfo', { user: 'metye' })
   const user2 = await client.user.getInfo('metye')
 
-  console.log(
-    user1.user.playcount,
-    user2.images
-  )
+  console.log(user2.playCount)
   
   const recentTracks = await client.user.getRecentTracksPaginated('metye', {
     extended: false
@@ -54,13 +50,22 @@ async function main() {
 
   const nonExistingTrack = await client.track.getInfo('21 Reasons', 'SEULBI')
   deepStrictEqual(nonExistingTrack, undefined)
-  console.log(`blueslimee has ${trackInfo2!.user!.playCount} plays on ${trackInfo2!.name} vs ${trackInfo!.track!.userplaycount} plays on ${trackInfo!.track!.name}`)
-  
+  console.log(`blueslimee has ${trackInfo2!.user!.playCount} plays on ${trackInfo2!.name} vs. ${trackInfo!.track!.userplaycount} plays on ${trackInfo!.track!.name}`)
+
+  const albumInfo = await client.request('album.getInfo', {
+    artist: 'Sabrina Carpenter',
+    album: 'Singular Act I',
+    username: 'blueslimee'
+  })
+  const albumInfo2 = await client.album.getInfo('emails i can\'t send', 'Sabrina Carpenter', {
+    username: 'blueslimee',
+    biographyLanguage: 'por'
+  })
+  console.log(`blueslimee has ${albumInfo2!.user!.playCount} plays on ${albumInfo2!.name} vs. ${albumInfo!.album!.userplaycount} plays on ${albumInfo!.album!.name}`)
+
   const page1 = recentTracks.getPage(1)
   const page2 = await recentTracks.fetchPage(2)
-  console.log(page1[2])
 
   console.log(page1[0].name, '- is listening now:', page1[0].nowPlaying)
-  console.log(page2[0].name)
 }
 main()

--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -63,6 +63,15 @@ async function main() {
   })
   console.log(`blueslimee has ${albumInfo2!.user!.playCount} plays on ${albumInfo2!.name} vs. ${albumInfo!.album!.userplaycount} plays on ${albumInfo!.album!.name}`)
 
+  const artistInfo = await client.request('artist.getInfo', {
+    artist: 'Artic Monkeys',
+    username: 'MysteryMS'
+  })
+  const artistInfo2 = await client.artist.getInfo('Kendrick Lamar', {
+    username: 'MysteryMS'
+  })
+  console.log(`MysteryMS has ${artistInfo2!.user!.playCount} plays on ${artistInfo2!.name} vs. ${artistInfo!.artist!.stats!.userplaycount} plays on ${artistInfo!.artist!.name}`)
+
   const page1 = recentTracks.getPage(1)
   const page2 = await recentTracks.fetchPage(2)
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musicorum/lastfm",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "dist/LastClient.js",
   "types": "dist/LastClient.d.ts",

--- a/lib/src/LastClient.ts
+++ b/lib/src/LastClient.ts
@@ -2,12 +2,13 @@
 import { LastfmError } from './error/LastfmError.js'
 import { User } from './packages/User.js'
 import { Track } from './packages/Track.js'
+import { Album } from './packages/Album.js'
+import { Artist } from './packages/Artist.js'
 import type {
   GetOriginalResponse,
   LastfmApiMethod,
   LastfmResponses
 } from './types/responses'
-import { Album } from './packages/Album.js'
 
 export class LastClient {
   private apiUrl = 'https://ws.audioscrobbler.com/2.0'
@@ -15,6 +16,7 @@ export class LastClient {
   public user = new User(this)
   public track = new Track(this)
   public album = new Album(this)
+  public artist = new Artist(this)
 
   constructor(
     public apiKey: string,

--- a/lib/src/LastClient.ts
+++ b/lib/src/LastClient.ts
@@ -7,12 +7,14 @@ import type {
   LastfmApiMethod,
   LastfmResponses
 } from './types/responses'
+import { Album } from './packages/Album.js'
 
 export class LastClient {
   private apiUrl = 'https://ws.audioscrobbler.com/2.0'
 
   public user = new User(this)
   public track = new Track(this)
+  public album = new Album(this)
 
   constructor(
     public apiKey: string,

--- a/lib/src/packages/Album.ts
+++ b/lib/src/packages/Album.ts
@@ -1,0 +1,73 @@
+import { LastClient } from '../LastClient.js'
+import { GetFormattedResponse, LastfmResponses } from '../types/responses.js'
+import { parseLastfmImages } from '../utils.js'
+import { LastfmTag } from '../types/packages/common.js'
+import {
+  LastfmAlbumInfoParams,
+  LastfmAlbumInfoTrack,
+  LastfmOriginalAlbumInfoTrackResponse
+} from '../types/packages/album.js'
+
+const parseAlbumInfoTracks = (
+  tracks: LastfmOriginalAlbumInfoTrackResponse[]
+): LastfmAlbumInfoTrack[] => {
+  return tracks.map((track) => ({
+    name: track.name,
+    duration: track.duration,
+    artist: {
+      name: track.artist.name,
+      mbid: track.artist.mbid ?? undefined,
+      url: track.artist.url
+    },
+    url: track.url,
+    rank: track['@attr']?.rank ?? undefined
+  }))
+}
+export class Album {
+  constructor(private client: LastClient) {}
+
+  async getInfo(
+    albumName: string,
+    artistName: string,
+    params?: LastfmAlbumInfoParams
+  ): Promise<
+    GetFormattedResponse<LastfmResponses['album.getInfo']> | undefined
+  > {
+    const original = await this.client.request('album.getInfo', {
+      album: albumName,
+      artist: artistName,
+      mbid: params?.mbid,
+      autocorrect: params?.autoCorrect === true ? '1' : '0',
+      username: params?.username,
+      lang: params?.biographyLanguage
+    })
+    if (!original.album) return undefined
+
+    return {
+      artist: original.album.artist,
+      images: original.album.image
+        ? parseLastfmImages(original.album.image)
+        : undefined,
+      listeners: parseInt(original.album.listeners),
+      mbid: original.album.mbid !== '' ? original.album.mbid : undefined,
+      name: original.album.name,
+      playCount: parseInt(original.album.playcount),
+      tags: original.album.tags?.tag as LastfmTag[],
+      tracks: original.album.tracks?.track
+        ? parseAlbumInfoTracks(original.album.tracks?.track)
+        : undefined,
+      url: original.album.url,
+      user: original.album.userplaycount
+        ? { playCount: original.album.userplaycount }
+        : undefined,
+
+      wiki: original.album.wiki
+        ? {
+            published: new Date(original.album.wiki.published),
+            summary: original.album.wiki.summary,
+            content: original.album.wiki.content
+          }
+        : undefined
+    }
+  }
+}

--- a/lib/src/packages/Artist.ts
+++ b/lib/src/packages/Artist.ts
@@ -1,0 +1,67 @@
+import { LastClient } from '../LastClient.js'
+import { GetFormattedResponse, LastfmResponses } from '../types/responses.js'
+import { parseLastfmImages } from '../utils.js'
+import { LastfmTag } from '../types/packages/common.js'
+import {
+  LastfmArtistInfoParams,
+  LastfmArtistInfoSimilarArtist,
+  LastfmOriginalArtistInfoSimilarArtistResponse
+} from '../types/packages/artist'
+
+const parseSimilarArtists = (
+  similarArtists: LastfmOriginalArtistInfoSimilarArtistResponse[]
+): LastfmArtistInfoSimilarArtist[] => {
+  return similarArtists.map((similarArtist) => ({
+    name: similarArtist.name,
+    url: similarArtist.url,
+    images: similarArtist.image
+      ? parseLastfmImages(similarArtist.image)
+      : undefined
+  }))
+}
+export class Artist {
+  constructor(private client: LastClient) {}
+
+  async getInfo(
+    artistName: string,
+    params?: LastfmArtistInfoParams
+  ): Promise<
+    GetFormattedResponse<LastfmResponses['artist.getInfo']> | undefined
+  > {
+    const original = await this.client.request('artist.getInfo', {
+      artist: artistName,
+      mbid: params?.mbid,
+      autocorrect: params?.autoCorrect === true ? '1' : '0',
+      username: params?.username,
+      lang: params?.biographyLanguage
+    })
+    if (!original.artist) return undefined
+
+    return {
+      name: original.artist.name,
+      mbid: original.artist.mbid,
+      url: original.artist.url,
+      images: original.artist.image
+        ? parseLastfmImages(original.artist.image)
+        : undefined,
+      streamable: original.artist.streamable === '1',
+      onTour: original.artist.ontour === '1',
+      listeners: parseInt(original.artist.stats.listeners),
+      playCount: parseInt(original.artist.stats.playcount),
+      user: original.artist.stats.userplaycount
+        ? { playCount: parseInt(original.artist.stats.userplaycount) }
+        : undefined,
+      similarArtists: original.artist.similar?.artist
+        ? parseSimilarArtists(original.artist.similar.artist)
+        : undefined,
+      tags: original.artist.tags?.tag as LastfmTag[],
+      wiki: original.artist.bio
+        ? {
+            published: new Date(original.artist.bio.published),
+            summary: original.artist.bio.summary,
+            content: original.artist.bio.content
+          }
+        : undefined
+    }
+  }
+}

--- a/lib/src/packages/Track.ts
+++ b/lib/src/packages/Track.ts
@@ -1,0 +1,65 @@
+import { LastClient } from '../LastClient.js'
+import { GetFormattedResponse, LastfmResponses } from '../types/responses.js'
+import { parseLastfmImages } from '../utils.js'
+import { LastfmTrackInfoParams } from '../types/packages/track.js'
+import { LastfmTag } from '../types/packages/common.js'
+
+export class Track {
+  constructor(private client: LastClient) {}
+
+  async getInfo(
+    trackName: string,
+    artistName: string,
+    params?: LastfmTrackInfoParams
+  ): Promise<GetFormattedResponse<LastfmResponses['track.getInfo']>> {
+    const original = await this.client.request('track.getInfo', {
+      track: trackName,
+      artist: artistName,
+      autocorrect: params?.autoCorrect === true ? '1' : '0',
+      username: params?.username
+    })
+
+    return {
+      user:
+        typeof original.track.userloved === 'string'
+          ? {
+              loved: original.track.userloved === '1',
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              playCount: parseInt(original.track.userplaycount!)
+            }
+          : undefined,
+      name: original.track.name,
+      mbid: original.track.mbid ?? undefined,
+      url: original.track.url,
+      duration:
+        original.track.duration !== '0'
+          ? parseInt(original.track.duration)
+          : undefined,
+      listeners: parseInt(original.track.listeners),
+      playcount: parseInt(original.track.playcount),
+      artist: {
+        name: original.track.artist.name,
+        mbid: original.track.artist.mbid ?? undefined,
+        url: original.track.artist.url
+      },
+      album: original.track.album
+        ? {
+            name: original.track.album.title,
+            artist: original.track.album.artist,
+            url: original.track.album.url,
+            images: original.track.album.image
+              ? parseLastfmImages(original.track.album.image)
+              : undefined
+          }
+        : undefined,
+      tags: original.track.toptags?.tag as LastfmTag[],
+      wiki: original.track.wiki
+        ? {
+            published: new Date(original.track.wiki.published),
+            summary: original.track.wiki.summary,
+            content: original.track.wiki.content
+          }
+        : undefined
+    }
+  }
+}

--- a/lib/src/packages/Track.ts
+++ b/lib/src/packages/Track.ts
@@ -17,6 +17,7 @@ export class Track {
     const original = await this.client.request('track.getInfo', {
       track: trackName,
       artist: artistName,
+      mbid: params?.mbid,
       autocorrect: params?.autoCorrect === true ? '1' : '0',
       username: params?.username
     })

--- a/lib/src/packages/Track.ts
+++ b/lib/src/packages/Track.ts
@@ -11,13 +11,16 @@ export class Track {
     trackName: string,
     artistName: string,
     params?: LastfmTrackInfoParams
-  ): Promise<GetFormattedResponse<LastfmResponses['track.getInfo']>> {
+  ): Promise<
+    GetFormattedResponse<LastfmResponses['track.getInfo']> | undefined
+  > {
     const original = await this.client.request('track.getInfo', {
       track: trackName,
       artist: artistName,
       autocorrect: params?.autoCorrect === true ? '1' : '0',
       username: params?.username
     })
+    if (!original.track) return undefined
 
     return {
       user:

--- a/lib/src/types/packages/album.ts
+++ b/lib/src/types/packages/album.ts
@@ -11,6 +11,7 @@ export interface LastfmOriginalAlbumInfoTrackResponse {
   streamable: StringRecord<'fulltrack' | '#text'>
   name: string
   duration?: number
+  images: LastfmRawImage[]
   artist: StringRecord<'mbid' | 'name' | 'url'>
   url: string
   '@attr'?: {

--- a/lib/src/types/packages/album.ts
+++ b/lib/src/types/packages/album.ts
@@ -80,7 +80,7 @@ export interface LastfmAlbumInfoParams {
    */
   mbid?: string
   /**
-   *  Whether to correct any spelling mistakes in the artist and track names. Returns the corrected version.
+   *  Whether to correct any spelling mistakes in the artist and album names. Returns the corrected version.
    */
   autoCorrect?: boolean
   /**

--- a/lib/src/types/packages/album.ts
+++ b/lib/src/types/packages/album.ts
@@ -1,0 +1,95 @@
+import type {
+  LastfmImage,
+  LastfmRawImage,
+  LastfmRawWikiData,
+  LastfmTag,
+  LastfmWikiData,
+  StringRecord
+} from './common'
+
+export interface LastfmOriginalAlbumInfoTrackResponse {
+  streamable: StringRecord<'fulltrack' | '#text'>
+  name: string
+  duration?: number
+  artist: StringRecord<'mbid' | 'name' | 'url'>
+  url: string
+  '@attr'?: {
+    rank: number
+  }
+}
+
+export interface LastfmOriginalAlbumInfoResponse {
+  album?: {
+    name: string
+    artist: string
+    playcount: string
+    listeners: string
+    streamable: StringRecord<'fulltrack' | '#text'>
+    image?: LastfmRawImage[]
+    mbid: string
+    url: string
+    userplaycount?: number
+    tags?: {
+      tag: LastfmTag[]
+    }
+    wiki?: LastfmRawWikiData
+    tracks?: {
+      track: LastfmOriginalAlbumInfoTrackResponse[]
+    }
+  }
+}
+
+// album.getInfo
+export interface LastfmAlbumInfoTrack {
+  name: string
+  duration?: number
+  artist: {
+    name: string
+    mbid?: string
+    url: string
+  }
+  url: string
+  rank?: number
+}
+export interface LastfmAlbumInfo {
+  name: string
+  artist: string
+  url: string
+  images?: LastfmImage[]
+  mbid?: string
+  playCount: number
+  listeners: number
+  tags?: LastfmTag[]
+  wiki?: LastfmWikiData
+  tracks?: LastfmAlbumInfoTrack[]
+  user?: {
+    playCount: number
+  }
+}
+/**
+ * Information regarding an album (from album.getInfo).
+ *
+ * {@link https://www.last.fm/api/show/album.getInfo API Reference}
+ */
+export interface LastfmAlbumInfoParams {
+  /**
+   * The MusicBrainz ID for the album
+   * > ⚠ **Warning**
+   * > Using the `mbid` will get you the wrong track most of the time. Save yourself the trouble and don't use it.
+   */
+  mbid?: string
+  /**
+   *  Whether to correct any spelling mistakes in the artist and track names. Returns the corrected version.
+   */
+  autoCorrect?: boolean
+  /**
+   * The username for the context of the request. If supplied, the user's playcount for this album is included in the response.
+   */
+  username?: string
+  /**
+   * The language to return the biography in, expressed as an ISO 639 alpha-2 code (e.g. `es` for Spanish, `de` for German, etc).
+   * > 🗒 **Note**
+   * > Using a non-existent language will return undefined for the `wiki` property.
+   */
+  biographyLanguage?: string
+}

--- a/lib/src/types/packages/artist.ts
+++ b/lib/src/types/packages/artist.ts
@@ -1,0 +1,87 @@
+import type {
+  LastfmImage,
+  LastfmRawImage,
+  LastfmRawWikiData,
+  LastfmTag,
+  LastfmWikiData
+} from './common'
+
+export interface LastfmOriginalArtistInfoSimilarArtistResponse {
+  name: string
+  image?: LastfmRawImage[]
+  url: string
+}
+
+export interface LastfmOriginalArtistInfoResponse {
+  artist?: {
+    name: string
+    image?: LastfmRawImage[]
+    mbid?: string
+    url: string
+    streamable: '0' | '1'
+    ontour: '0' | '1'
+    stats: {
+      listeners: string
+      playcount: string
+      userplaycount?: string
+    }
+    similar?: {
+      artist: LastfmOriginalArtistInfoSimilarArtistResponse[]
+    }
+    tags?: {
+      tag: LastfmTag[]
+    }
+    bio?: LastfmRawWikiData
+  }
+}
+
+// artist.getInfo
+export interface LastfmArtistInfoSimilarArtist {
+  name: string
+  url: string
+  images?: LastfmImage[]
+}
+export interface LastfmArtistInfo {
+  name: string
+  mbid?: string
+  url: string
+  images?: LastfmImage[]
+  streamable: boolean
+  onTour: boolean
+  listeners: number
+  playCount: number
+  user?: {
+    playCount: number
+  }
+  similarArtists?: LastfmArtistInfoSimilarArtist[]
+  tags?: LastfmTag[]
+  wiki?: LastfmWikiData
+}
+
+/**
+ * Information regarding an artist (from artist.getInfo).
+ *
+ * {@link https://www.last.fm/api/show/artist.getInfo API Reference}
+ */
+export interface LastfmArtistInfoParams {
+  /**
+   * The MusicBrainz ID for the artist
+   * > ⚠ **Warning**
+   * > Using the `mbid` will get you the wrong track most of the time. Save yourself the trouble and don't use it.
+   */
+  mbid?: string
+  /**
+   *  Whether to correct any spelling mistakes in the artist name. Returns the corrected version.
+   */
+  autoCorrect?: boolean
+  /**
+   * The username for the context of the request. If supplied, the user's playcount for this artist is included in the response.
+   */
+  username?: string
+  /**
+   * The language to return the biography in, expressed as an ISO 639 alpha-2 code (e.g. `es` for Spanish, `de` for German, etc).
+   * > 🗒 **Note**
+   * > Using a non-existent language will return undefined for the `wiki` property.
+   */
+  biographyLanguage?: string
+}

--- a/lib/src/types/packages/common.ts
+++ b/lib/src/types/packages/common.ts
@@ -17,6 +17,18 @@ export interface LastfmImage {
   url: string
 }
 
+export interface LastfmRawWikiData {
+  published: string
+  summary: string
+  content: string
+}
+
+export interface LastfmWikiData {
+  published: Date
+  summary: string
+  content: string
+}
+
 export type PaginatedResponseAttributes<EXTRA extends string = never> = {
   totalPages: string
   page: string
@@ -25,3 +37,5 @@ export type PaginatedResponseAttributes<EXTRA extends string = never> = {
 } & { [K in EXTRA]: string }
 
 export type LastfmDate = StringRecord<'uts' | '#text'>
+
+export type LastfmTag = StringRecord<'name' | 'url'>

--- a/lib/src/types/packages/track.ts
+++ b/lib/src/types/packages/track.ts
@@ -1,0 +1,84 @@
+import type {
+  LastfmImage,
+  LastfmRawImage,
+  LastfmRawWikiData,
+  LastfmTag,
+  LastfmWikiData,
+  StringRecord
+} from './common'
+
+export interface LastfmOriginalTrackInfoResponse {
+  track: {
+    artist: StringRecord<'mbid' | 'name' | 'url'>
+    streamable: StringRecord<'fulltrack' | '#text'>
+    image?: LastfmRawImage[]
+    mbid: string
+    album?: {
+      artist: string
+      title: string
+      url: string
+      image?: LastfmRawImage[]
+    }
+    name: string
+    duration: string
+    listeners: string
+    playcount: string
+    url: string
+    userplaycount?: string
+    userloved?: '0' | '1'
+    toptags?: {
+      tag: LastfmTag[]
+    }
+    wiki?: LastfmRawWikiData
+  }
+}
+
+// user.getInfo
+export interface LastfmTrackInfo {
+  name: string
+  mbid: string
+  url: string
+  artist: {
+    name: string
+    mbid?: string
+    url: string
+  }
+  album?: {
+    name: string
+    artist: string
+    url: string
+    images?: LastfmImage[]
+  }
+  duration?: number
+  listeners: number
+  playcount: number
+  tags?: LastfmTag[]
+  user?: {
+    playCount: number
+    loved: boolean
+  }
+  wiki?: LastfmWikiData
+}
+
+// track.getInfo
+/**
+ * Information regarding a track (from track.getInfo).
+ *
+ * {@link https://www.last.fm/api/show/track.getInfo API Reference}
+ */
+export interface LastfmTrackInfoParams {
+  /**
+   * The MusicBrainz ID for the track
+   * > ⚠ **Warning**
+   * > Using the `mbid` will get you the wrong track most of the time. Save yourself the trouble and don't use it.
+   */
+  mbid?: string
+  /**
+   *  Whether to correct any spelling mistakes in the artist and track names. Returns the corrected version.
+   */
+  autoCorrect?: boolean
+  /**
+   * The username for the context of the request. If supplied, the user's playcount for this track and whether they have loved the track is included in the response.
+   */
+  username?: string
+}

--- a/lib/src/types/packages/track.ts
+++ b/lib/src/types/packages/track.ts
@@ -8,7 +8,7 @@ import type {
 } from './common'
 
 export interface LastfmOriginalTrackInfoResponse {
-  track: {
+  track?: {
     artist: StringRecord<'mbid' | 'name' | 'url'>
     streamable: StringRecord<'fulltrack' | '#text'>
     image?: LastfmRawImage[]

--- a/lib/src/types/packages/track.ts
+++ b/lib/src/types/packages/track.ts
@@ -12,7 +12,7 @@ export interface LastfmOriginalTrackInfoResponse {
     artist: StringRecord<'mbid' | 'name' | 'url'>
     streamable: StringRecord<'fulltrack' | '#text'>
     image?: LastfmRawImage[]
-    mbid: string
+    mbid?: string
     album?: {
       artist: string
       title: string
@@ -33,10 +33,10 @@ export interface LastfmOriginalTrackInfoResponse {
   }
 }
 
-// user.getInfo
+// track.getInfo
 export interface LastfmTrackInfo {
   name: string
-  mbid: string
+  mbid?: string
   url: string
   artist: {
     name: string

--- a/lib/src/types/packages/user.ts
+++ b/lib/src/types/packages/user.ts
@@ -65,7 +65,7 @@ export interface LastfmUserRecentTracksParams {
    */
   to?: Date
   /**
-   * Extended response includes whether or not the user has loved each track
+   * Extended response includes whether the user has loved each track
    * The API also returns images for the artists of each track, but this is omitted since it defaults to a default image
    */
   extended?: boolean

--- a/lib/src/types/responses.ts
+++ b/lib/src/types/responses.ts
@@ -8,6 +8,10 @@ import {
   LastfmOriginalTrackInfoResponse,
   LastfmTrackInfo
 } from './packages/track'
+import {
+  LastfmAlbumInfo,
+  LastfmOriginalAlbumInfoResponse
+} from './packages/album'
 
 export interface LastfmErrorResponse {
   error: number
@@ -34,6 +38,10 @@ export type LastfmResponses = {
   'track.getInfo': LastfmResponse<
     LastfmOriginalTrackInfoResponse,
     LastfmTrackInfo
+  >
+  'album.getInfo': LastfmResponse<
+    LastfmOriginalAlbumInfoResponse,
+    LastfmAlbumInfo
   >
 }
 

--- a/lib/src/types/responses.ts
+++ b/lib/src/types/responses.ts
@@ -12,6 +12,10 @@ import {
   LastfmAlbumInfo,
   LastfmOriginalAlbumInfoResponse
 } from './packages/album'
+import {
+  LastfmArtistInfo,
+  LastfmOriginalArtistInfoResponse
+} from './packages/artist'
 
 export interface LastfmErrorResponse {
   error: number
@@ -42,6 +46,10 @@ export type LastfmResponses = {
   'album.getInfo': LastfmResponse<
     LastfmOriginalAlbumInfoResponse,
     LastfmAlbumInfo
+  >
+  'artist.getInfo': LastfmResponse<
+    LastfmOriginalArtistInfoResponse,
+    LastfmArtistInfo
   >
 }
 

--- a/lib/src/types/responses.ts
+++ b/lib/src/types/responses.ts
@@ -4,6 +4,10 @@ import type {
   LastfmOriginalUserTopArtistsResponse,
   LastfmUserInfo
 } from './packages/user'
+import {
+  LastfmOriginalTrackInfoResponse,
+  LastfmTrackInfo
+} from './packages/track'
 
 export interface LastfmErrorResponse {
   error: number
@@ -27,6 +31,10 @@ export type LastfmResponses = {
     LastfmOriginalUserRecentTracksResponse<true | false>
   >
   'user.getTopArtists': LastfmResponse<LastfmOriginalUserTopArtistsResponse>
+  'track.getInfo': LastfmResponse<
+    LastfmOriginalTrackInfoResponse,
+    LastfmTrackInfo
+  >
 }
 
 export type LastfmApiMethod = keyof LastfmResponses


### PR DESCRIPTION
This PR adds support for the following last.fm methods:
- `artist.getInfo`;
- `album.getInfo`;
- `track.getInfo`.
