### PR TITLE
Signed requests and auth package

### DIFF
--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -3,7 +3,7 @@ import { deepStrictEqual } from 'assert'
 
 class MonitoredClient extends LastClient {
   constructor () {
-    super(process.env.LASTFM_KEY!)
+    super(process.env.LASTFM_KEY!, process.env.LASTFM_SECRET!)
   }
 
   onRequestStarted(
@@ -76,5 +76,20 @@ async function main() {
   const page2 = await recentTracks.fetchPage(2)
 
   console.log(page1[0].name, '- is listening now:', page1[0].nowPlaying)
+
+  console.log('waiting 5 seconds to proceed testing')
+  await new Promise(resolve => setTimeout(resolve, 5000))
+
+  const token = await client.auth.getToken()
+  const url = client.utilities.buildDesktopAuthURL(token)
+
+  console.log('paste in this url in your browser:', url)
+  console.log('press enter once you have authorized the app')
+  await new Promise(resolve => process.stdin.once('data', resolve))
+
+  const session = await client.auth.getSession(token)
+  console.log(`hello ${session.username}! your session key is ${session.key}. subscriber? ${session.subscriber}`)
+
+  process.exit(0)
 }
 main()

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musicorum/lastfm",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "dist/LastClient.js",
   "types": "dist/LastClient.d.ts",

--- a/lib/src/LastClient.ts
+++ b/lib/src/LastClient.ts
@@ -53,8 +53,6 @@ export class LastClient {
   ) {
     if (signed && !this.apiSecret)
       throw new Error('apiSecret is required for signed requests')
-    if (signed && !this.sessionToken && !params?.['sk'])
-      throw new Error('sessionKey is required for signed requests')
 
     params = {
       ...params,
@@ -69,9 +67,6 @@ export class LastClient {
 
     const searchParams = new URLSearchParams(cleanParams)
     if (signed) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      if (!params!.sk) searchParams.set('sk', this.sessionToken!)
-
       // order cleanParams alphabetically by key
       const orderedParams = Object.fromEntries(
         Object.entries(cleanParams).sort(([a], [b]) => a.localeCompare(b))

--- a/lib/src/LastClient.ts
+++ b/lib/src/LastClient.ts
@@ -4,6 +4,8 @@ import { User } from './packages/User.js'
 import { Track } from './packages/Track.js'
 import { Album } from './packages/Album.js'
 import { Artist } from './packages/Artist.js'
+import { Auth } from './packages/Auth.js'
+import { Utilities } from './packages/Utilities.js'
 import type {
   GetOriginalResponse,
   LastfmApiMethod,
@@ -18,6 +20,8 @@ export class LastClient {
   public track = new Track(this)
   public album = new Album(this)
   public artist = new Artist(this)
+  public auth = new Auth(this)
+  public utilities = new Utilities(this)
 
   constructor(
     public apiKey: string,
@@ -74,6 +78,7 @@ export class LastClient {
 
       const signature =
         Object.entries(orderedParams)
+          .filter(([k]) => k !== 'format')
           .map(([k, v]) => `${k}${v}`)
           .join('') + this.apiSecret
 

--- a/lib/src/packages/Auth.ts
+++ b/lib/src/packages/Auth.ts
@@ -1,0 +1,26 @@
+import type { LastClient } from '../LastClient'
+import type { GetFormattedResponse, LastfmResponses } from '../types/responses'
+
+export class Auth {
+  constructor(private client: LastClient) {}
+
+  async getToken(): Promise<string> {
+    const original = await this.client.request('auth.getToken', undefined, true)
+    return original.token
+  }
+
+  async getSession(
+    token: string
+  ): Promise<GetFormattedResponse<LastfmResponses['auth.getSession']>> {
+    const original = await this.client.request(
+      'auth.getSession',
+      { token },
+      true
+    )
+    return {
+      username: original.session.name,
+      key: original.session.key,
+      subscriber: original.session.subscriber === '1'
+    }
+  }
+}

--- a/lib/src/packages/Utilities.ts
+++ b/lib/src/packages/Utilities.ts
@@ -1,0 +1,12 @@
+import type { LastClient } from '../LastClient'
+
+export class Utilities {
+  constructor(private client: LastClient) {}
+
+  /**
+   * Returns the URL to the Last.fm authentication page
+   */
+  buildDesktopAuthURL(token: string): string {
+    return `https://www.last.fm/api/auth/?api_key=${this.client.apiKey}&token=${token}`
+  }
+}

--- a/lib/src/types/packages/auth.ts
+++ b/lib/src/types/packages/auth.ts
@@ -1,0 +1,17 @@
+export interface LastfmAuthGetTokenResponse {
+  token: string
+}
+
+export interface LastfmOriginalAuthGetSessionResponse {
+  session: {
+    name: string
+    key: string
+    subscriber: '0' | '1'
+  }
+}
+
+export interface LastfmAuthGetSessionResponse {
+  username: string
+  key: string
+  subscriber: boolean
+}

--- a/lib/src/types/responses.ts
+++ b/lib/src/types/responses.ts
@@ -16,6 +16,11 @@ import {
   LastfmArtistInfo,
   LastfmOriginalArtistInfoResponse
 } from './packages/artist'
+import {
+  LastfmAuthGetSessionResponse,
+  LastfmAuthGetTokenResponse,
+  LastfmOriginalAuthGetSessionResponse
+} from './packages/auth'
 
 export interface LastfmErrorResponse {
   error: number
@@ -50,6 +55,11 @@ export type LastfmResponses = {
   'artist.getInfo': LastfmResponse<
     LastfmOriginalArtistInfoResponse,
     LastfmArtistInfo
+  >
+  'auth.getToken': LastfmResponse<LastfmAuthGetTokenResponse>
+  'auth.getSession': LastfmResponse<
+    LastfmOriginalAuthGetSessionResponse,
+    LastfmAuthGetSessionResponse
   >
 }
 


### PR DESCRIPTION
This PR implements the following functions:
- `auth.getToken`
- `auth.getSession`
- Signed requests
- A new package called `Utilities` for useful functions (currently only has 1 method, `buildDesktopAuthURL`)