### PR TITLE
fix(album): handle single track response in album info

### DIFF
--- a/src/packages/Album.ts
+++ b/src/packages/Album.ts
@@ -54,7 +54,11 @@ export class Album {
       playCount: parseInt(original.album.playcount),
       tags: original.album.tags?.tag as LastfmTag[],
       tracks: original.album.tracks?.track
-        ? parseAlbumInfoTracks(original.album.tracks?.track)
+        ? parseAlbumInfoTracks(
+            Array.isArray(original.album.tracks?.track)
+              ? original.album.tracks?.track
+              : [original.album.tracks?.track]
+          )
         : undefined,
       url: original.album.url,
       user: original.album.userplaycount

--- a/src/types/packages/album.ts
+++ b/src/types/packages/album.ts
@@ -35,7 +35,9 @@ export interface LastfmOriginalAlbumInfoResponse {
     }
     wiki?: LastfmRawWikiData
     tracks?: {
-      track: LastfmOriginalAlbumInfoTrackResponse[]
+      track:
+        | LastfmOriginalAlbumInfoTrackResponse
+        | LastfmOriginalAlbumInfoTrackResponse[]
     }
   }
 }


### PR DESCRIPTION
When an album only has a single track, the last.fm API returns the `track` object from the `album.getInfo` endpoint as a single `LastfmOriginalAlbumInfoTrackResponse` object, rather than an array of that object.

This will throw a `TypeError: tracks.map is not a function` error when trying to parse the response.

For reference, this can be reproduced with [Dorian Concept's Hide (CS01 Version)](https://www.last.fm/fr/music/Dorian+Concept/Hide+(CS01+Version)).