### PR TITLE
fix(track)!: rename `playcount` to `playCount` in `Track#getInfo()` result

### DIFF
--- a/src/packages/Track.ts
+++ b/src/packages/Track.ts
@@ -40,7 +40,7 @@ export class Track {
           ? parseInt(original.track.duration)
           : undefined,
       listeners: parseInt(original.track.listeners),
-      playcount: parseInt(original.track.playcount),
+      playCount: parseInt(original.track.playcount),
       artist: {
         name: original.track.artist.name,
         mbid: original.track.artist.mbid ?? undefined,

--- a/src/types/packages/track.ts
+++ b/src/types/packages/track.ts
@@ -51,7 +51,7 @@ export interface LastfmTrackInfo {
   }
   duration?: number
   listeners: number
-  playcount: number
+  playCount: number
   tags?: LastfmTag[]
   user?: {
     playCount: number


### PR DESCRIPTION
BREAKING CHANGE: The `Track#getInfo()` method returns `playcount` (all lowercase), which is most likely a typo, since every other method (e.g., `Artist#getInfo()`, `Album#getInfo()`, etc.) consistently maps this field to camelCase `playCount`.