### PR TITLE
fix: properly re-export `LastfmError.ts` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.4",
   "description": "",
   "main": "dist/index.js",
-  "types": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
     "build": "npx rollup --config rollup.config.js",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@musicorum/lastfm",
   "version": "0.3.4",
   "description": "",
-  "main": "dist/LastClient.js",
-  "types": "dist/LastClient.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.js",
   "type": "module",
   "scripts": {
     "build": "npx rollup --config rollup.config.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,10 @@
-import typescript from '@rollup/plugin-typescript';
+import typescript from '@rollup/plugin-typescript'
 
 export default {
-  input: ['src/LastClient.ts', 'src/error/LastfmError.ts'],
+  input: ['src/index.ts'],
   output: {
     dir: 'dist',
     format: 'es'
   },
   plugins: [typescript()]
-};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export * from './LastClient.js'
+export * from './error/LastfmError.js'


### PR DESCRIPTION
Previously, the `LastfmError.ts` file wasn’t properly re‑exported, which made it harder for users to properly catch Lastfm-related errors.